### PR TITLE
Moved Service attributes to registry

### DIFF
--- a/docs/attributes-registry/README.md
+++ b/docs/attributes-registry/README.md
@@ -47,6 +47,7 @@ Currently, the following namespaces exist:
 * [Process](process.md)
 * [RPC](rpc.md)
 * [Server](server.md)
+* [Service](service.md)
 * [Source](source.md)
 * [Thread](thread.md)
 * [TLS](tls.md)

--- a/docs/attributes-registry/service.md
+++ b/docs/attributes-registry/service.md
@@ -1,10 +1,23 @@
 # Service
 
-<!-- semconv service(omit_requirement_level) -->
+<!-- semconv registry.service(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `service.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Logical name of the service. [1] | `shoppingcart` |
 | `service.version` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1]:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+<!-- endsemconv -->
+
+# Service (Experimental)
+
+<!-- semconv registry.service_experimental(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `service.instance.id` | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` |
+| `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` |
+
+**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
+
+**[2]:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 <!-- endsemconv -->

--- a/docs/attributes-registry/service.md
+++ b/docs/attributes-registry/service.md
@@ -1,0 +1,10 @@
+# Service
+
+<!-- semconv service(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `service.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Logical name of the service. [1] | `shoppingcart` |
+| `service.version` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
+
+**[1]:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+<!-- endsemconv -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -82,8 +82,8 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 <!-- semconv service -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `service.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Logical name of the service. [1] | `shoppingcart` | Required |
-| `service.version` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | Recommended |
+| [`service.name`](../attributes-registry/service.md) | string | Logical name of the service. [1] | `shoppingcart` | Required |
+| [`service.version`](../attributes-registry/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | Recommended |
 
 **[1]:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 <!-- endsemconv -->
@@ -99,8 +99,8 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 <!-- semconv service_experimental -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `service.instance.id` | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
-| `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
+| [`service.instance.id`](../attributes-registry/service.md) | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
+| [`service.namespace`](../attributes-registry/service.md) | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
 
 **[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
 

--- a/model/registry/service.yaml
+++ b/model/registry/service.yaml
@@ -1,0 +1,22 @@
+groups:
+  - id: registry.service
+    prefix: service
+    type: attribute_group
+    brief: >
+      A service instance.
+    attributes:
+      - id: name
+        type: string
+        brief: >
+          Logical name of the service.
+        note: >
+          MUST be the same for all instances of horizontally scaled services.
+          If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated
+          with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`.
+          If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+        examples: ["shoppingcart"]
+      - id: version
+        type: string
+        brief: >
+          The version string of the service API or implementation. The format is not defined by these conventions.
+        examples: ["2.0.0", "a01dbef8a"]

--- a/model/registry/service.yaml
+++ b/model/registry/service.yaml
@@ -15,8 +15,46 @@ groups:
           with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`.
           If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
         examples: ["shoppingcart"]
+        stability: stable
       - id: version
         type: string
         brief: >
           The version string of the service API or implementation. The format is not defined by these conventions.
         examples: ["2.0.0", "a01dbef8a"]
+        stability: stable
+  - id: registry.service_experimental
+    prefix: service
+    type: attribute_group
+    brief: >
+      A service instance.
+    attributes:
+      - id: namespace
+        type: string
+        brief: >
+          A namespace for `service.name`.
+        note: >
+          A string value having a meaning that helps to distinguish a group of services,
+          for example the team name that owns a group of services.
+          `service.name` is expected to be unique within the same namespace.
+          If `service.namespace` is not specified in the Resource then `service.name`
+          is expected to be unique for all services that have no explicit namespace defined
+          (so the empty/unspecified namespace is simply one more valid namespace).
+          Zero-length namespace string is assumed equal to unspecified namespace.
+        examples: ["Shop"]
+      - id: instance.id
+        type: string
+        brief: >
+          The string ID of the service instance.
+        note: >
+          MUST be unique for each instance of the same `service.namespace,service.name` pair
+          (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
+          The ID helps to distinguish instances of the same service that exist at the same time
+          (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
+          and stay the same for the lifetime of the service instance, however it is acceptable that
+          the ID is ephemeral and changes during important lifetime events for the service
+          (e.g. service restarts).
+          If the service has no inherent unique ID that can be used as the value of this attribute
+          it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID
+          (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122
+          for more recommendations).
+        examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service.yaml
+++ b/model/resource/service.yaml
@@ -5,21 +5,8 @@ groups:
     brief: >
       A service instance.
     attributes:
-      - id: name
-        type: string
-        stability: stable
+      - ref: service.name
         requirement_level: required
-        brief: >
-          Logical name of the service.
-        note: >
-          MUST be the same for all instances of horizontally scaled services.
-          If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated
-          with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`.
-          If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-        examples: ["shoppingcart"]
-      - id: version
-        type: string
         stability: stable
-        brief: >
-          The version string of the service API or implementation. The format is not defined by these conventions.
-        examples: ["2.0.0", "a01dbef8a"]
+      - ref: service.version
+        stability: stable

--- a/model/resource/service.yaml
+++ b/model/resource/service.yaml
@@ -7,6 +7,4 @@ groups:
     attributes:
       - ref: service.name
         requirement_level: required
-        stability: stable
       - ref: service.version
-        stability: stable

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -5,33 +5,5 @@ groups:
     brief: >
       A service instance.
     attributes:
-      - id: namespace
-        type: string
-        brief: >
-          A namespace for `service.name`.
-        note: >
-          A string value having a meaning that helps to distinguish a group of services,
-          for example the team name that owns a group of services.
-          `service.name` is expected to be unique within the same namespace.
-          If `service.namespace` is not specified in the Resource then `service.name`
-          is expected to be unique for all services that have no explicit namespace defined
-          (so the empty/unspecified namespace is simply one more valid namespace).
-          Zero-length namespace string is assumed equal to unspecified namespace.
-        examples: ["Shop"]
-      - id: instance.id
-        type: string
-        brief: >
-          The string ID of the service instance.
-        note: >
-          MUST be unique for each instance of the same `service.namespace,service.name` pair
-          (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
-          The ID helps to distinguish instances of the same service that exist at the same time
-          (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
-          and stay the same for the lifetime of the service instance, however it is acceptable that
-          the ID is ephemeral and changes during important lifetime events for the service
-          (e.g. service restarts).
-          If the service has no inherent unique ID that can be used as the value of this attribute
-          it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID
-          (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122
-          for more recommendations).
-        examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]
+      - ref: service.namespace
+      - ref: service.instance.id


### PR DESCRIPTION
## Changes

This PR is to moves `service` attributes to the attributes registry and make service resources reference the registry.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
